### PR TITLE
docs: add config for using database with `osv-detector`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ This database can be used by any tool that supports ingesting OSV advisories.
 
 If you are using [`osv-detector`](https://github.com/G-Rath/osv-detector), you
 can configure this database as an
-[extra database](https://github.com/G-Rath/osv-detector?tab=readme-ov-file#extra-databases)
+[extra database](https://github.com/G-Rath/osv-detector?tab=readme-ov-file#extra-databases):
+
+```yaml
+extra-databases:
+  - url: https://github.com/ackama/drupal-advisory-database/archive/refs/heads/main.zip
+    name: Drupal Advisory Database
+    working-directory: 'drupal-advisory-database-main/advisories'
+```
 
 ## Updating the advisories
 


### PR DESCRIPTION
Now that the repository is public, we can include the suitable configuration for using it with `osv-detector` which will just work out of the box