### PR TITLE
ci: have Renovate create a dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
+  "dependencyDashboard": true,
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {


### PR DESCRIPTION
The dependency dashboard can make it easy to ensure Renovate is working and allow us to manually trigger PRs