### PR TITLE
ci: adjust `python` dependency update grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "pinDigests": true
     },
     {
-      "matchCategories": ["pep621"],
+      "matchCategories": ["poetry"],
       "groupName": "python"
     }
   ]


### PR DESCRIPTION
Even though the dashboard reports `pep621`, based on the docs and logs that apparently only applies to `pdm.lock` and `uv.lock` files whereas `poetry.lock` has its own category