### PR TITLE
ci: use `[tool.poetry.dependencies]` instead of PEP-681 and update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,12 +4,15 @@
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
   "dependencyDashboard": true,
-  "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
       "matchDepTypes": ["action"],
       "groupName": "workflows",
       "pinDigests": true
+    },
+    {
+      "matchFileNames": ["pyproject.toml"],
+      "groupName": "python dependencies"
     }
   ]
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -653,4 +653,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.13"
-content-hash = "9ec0a7f1ae3f0197f6b1371a7c8c2da33404fb6be865b25d25136e0884dd2069"
+content-hash = "5bcbfd60d46e53fe198dd1207075a5c3f78d421b104e1ff79a27d37f7d077f5d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
 [project]
 name = "drupal-advisory-database"
 requires-python = ">= 3.13"
-dependencies = [
-  "jsonschema (>=4.23.0,<5.0.0)",
-  "markdownify (>=1.1.0,<2.0.0)",
-  "mypy (>=1.15.0,<2.0.0)",
-  "pytest (>=8.3.5,<9.0.0)",
-  "requests (>=2.32.3,<3.0.0)",
-  "ruff ~=0.11.5",
-  "semver (>=3.0.4,<4.0.0)",
-  "types-jsonschema (>=4.23.0.20241208,<5.0.0.0)",
-  "types-requests (>=2.32.0.20250328,<3.0.0.0)",
-]
+
+[tool.poetry.dependencies]
+jsonschema = "^4.23.0"
+markdownify = "^1.1.0"
+mypy = "^1.15.0"
+pytest = "^8.3.5"
+requests = "^2.32.3"
+ruff = "~0.11.5"
+semver = "^3.0.4"
+types-jsonschema = "^4.23.0.20241208"
+types-requests = "^2.32.0.20250328"
 
 [tool.poetry]
 package-mode = false


### PR DESCRIPTION
[Turns out Renovate don't yet support using Poetry with PEP-681 compliant `pyproject.toml` files](https://github.com/renovatebot/renovate/issues/33509) so this switches us to use the Poetry equivalent along with updating our Renovate config based on some further testing I've done in another repository .

This will result in Renovate using a single pull request for updating Python dependencies which we can land as we feel like it:

![image](https://github.com/user-attachments/assets/3219177e-d546-45b8-ae6c-a32fcba50697)
