### PR TITLE
fix: mention status code before node ids in exception message

### DIFF
--- a/scripts/precache_nodes.py
+++ b/scripts/precache_nodes.py
@@ -33,7 +33,7 @@ def fetch_drupal_nodes(nids: list[str]) -> list[drupal.Node]:
     if len(items) != len(nids):
       raise Exception(f'API returned {len(items)} nodes but expected {len(nids)}')
     return items
-  raise Exception(f'unexpected response when fetching nodes {nids}: {resp.status_code}')
+  raise Exception(f'unexpected {resp.status_code} response when fetching nodes {nids}')
 
 
 def fetch_and_cache_drupal_nodes() -> None:


### PR DESCRIPTION
This should make it a bit easier to read since `nids` is an array of up to 50 numbers so currently we get messages like:

```
Exception: unexpected response when fetching nodes ['1301730', '2999525', '2980066', '3263534', '3415185', '73594', '258223', '2942788', '3046066', '3145765', '1699634', '2425017', '2345891', '1762004', '2956120', '2649868', '1404150', '61442', '2684717', '632214', '225194', '1934188', '1883798', '607826', '173525', '436148', '2348769', '1408882', '20492', '925500', '147151', '2906646', '2579037', '259843', '1087226', '1302522', '2365459', '3066563', '3245777', '2788489', '3152933', '2705191', '169791', '1509408', '2846636', '19304', '3261896', '2887155', '3228985', '1909836']: 429
```

Whereas now we'll get:

```
Exception: unexpected 429 response when fetching nodes ['1301730', '2999525', '2980066', '3263534', '3415185', '73594', '258223', '2942788', '3046066', '3145765', '1699634', '2425017', '2345891', '1762004', '2956120', '2649868', '1404150', '61442', '2684717', '632214', '225194', '1934188', '1883798', '607826', '173525', '436148', '2348769', '1408882', '20492', '925500', '147151', '2906646', '2579037', '259843', '1087226', '1302522', '2365459', '3066563', '3245777', '2788489', '3152933', '2705191', '169791', '1509408', '2846636', '19304', '3261896', '2887155', '3228985', '1909836']
```