### PR TITLE
fix: patch affected versions for `SA-CONTRIB-2025-001`

### DIFF
--- a/advisories/email_tfa/DSA-CONTRIB-2025-001.json
+++ b/advisories/email_tfa/DSA-CONTRIB-2025-001.json
@@ -19,22 +19,20 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.1"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.0.3"
             }
           ],
           "database_specific": {
-            "constraint": ">2.0.0 <2.0.3",
-            "warnings": [
-              "the > operator should be avoided as it does not provide a concrete version"
-            ]
+            "constraint": ">=2.0.0 <2.0.3"
           }
         }
       ],
       "database_specific": {
-        "affected_versions": ">2.0.0 <2.0.3"
+        "affected_versions": ">=2.0.0 <2.0.3",
+        "patched": true
       }
     }
   ],

--- a/patches.toml
+++ b/patches.toml
@@ -52,6 +52,12 @@ field_affected_versions = [
   '<1.2.2 || >=1.3.0-beta1 <1.3.0-rc3'
 ]
 
+[SA-CONTRIB-2025-001]
+field_affected_versions = [
+  '>2.0.0 <2.0.3',
+  '>=2.0.0 <2.0.3'
+]
+
 [SA-CONTRIB-2025-003]
 field_affected_versions = [
   '>1.0.0 <1.0.2',


### PR DESCRIPTION
The advisory description doesn't mention the ranges at all so I've assumed the vulnerability was introduced in v2.0.0 rather than v2.0.1