### PR TITLE
chore: order patches by advisory year and number

### DIFF
--- a/patches.toml
+++ b/patches.toml
@@ -1,10 +1,11 @@
 # this file defines "patches" for specific drupal.org advisories
 
-[SA-CONTRIB-2024-025]
+[SA-CONTRIB-2019-019]
 field_affected_versions = [
-  '<1.0.13 || >=1.1.0 <1.1.0-beta3',
-  '<1.0.13 || >=1.1.0-beta1 <1.1.0-beta3'
+  '<1.25.0 || >=2.0.0 >2.3.0',
+  '<1.25.0 || >=2.0.0 <2.3.0'
 ]
+
 [SA-CORE-2022-002]
 field_affected_versions = [
   '>7.0 <=7.86',
@@ -17,16 +18,10 @@ field_affected_versions = [
   '<1.6.0'
 ]
 
-[SA-CONTRIB-2024-042]
+[SA-CONTRIB-2022-028]
 field_affected_versions = [
-  '<1.8.0 || >=2.0.0 <2.0.0-beta3',
-  '<1.8.0 || >=2.0.0-beta1 <2.0.0-beta3'
-]
-
-[SA-CONTRIB-2019-019]
-field_affected_versions = [
-  '<1.25.0 || >=2.0.0 >2.3.0',
-  '<1.25.0 || >=2.0.0 <2.3.0'
+  '<1.17.0 || =2.0.0',
+  '<1.17.0 || 2.0.0'
 ]
 
 [SA-CONTRIB-2023-013]
@@ -35,10 +30,28 @@ field_affected_versions = [
   '<1.6'
 ]
 
+[SA-CONTRIB-2023-030]
+field_affected_versions = [
+  '^1 <= 1.0.0',
+  '>=1.0.0 <1.1.0'
+]
+
+[SA-CONTRIB-2023-031]
+field_affected_versions = [
+  '<1.2.2 || >=1.3.0 <1.3.0-rc3',
+  '<1.2.2 || >=1.3.0-beta1 <1.3.0-rc3'
+]
+
 [SA-CONTRIB-2024-004]
 field_affected_versions = [
   '<12.05',
   '<12.0.5'
+]
+
+[SA-CONTRIB-2024-025]
+field_affected_versions = [
+  '<1.0.13 || >=1.1.0 <1.1.0-beta3',
+  '<1.0.13 || >=1.1.0-beta1 <1.1.0-beta3'
 ]
 
 [SA-CONTRIB-2024-038]
@@ -47,16 +60,10 @@ field_affected_versions = [
   '<12.3.8 || >=12.4.0 <12.4.5 || >=13.0.0-alpha1 <13.0.0-alpha11'
 ]
 
-[SA-CONTRIB-2022-028]
+[SA-CONTRIB-2024-042]
 field_affected_versions = [
-  '<1.17.0 || =2.0.0',
-  '<1.17.0 || 2.0.0'
-]
-
-[SA-CONTRIB-2023-031]
-field_affected_versions = [
-  '<1.2.2 || >=1.3.0 <1.3.0-rc3',
-  '<1.2.2 || >=1.3.0-beta1 <1.3.0-rc3'
+  '<1.8.0 || >=2.0.0 <2.0.0-beta3',
+  '<1.8.0 || >=2.0.0-beta1 <2.0.0-beta3'
 ]
 
 [SA-CONTRIB-2025-001]
@@ -69,12 +76,6 @@ field_affected_versions = [
 field_affected_versions = [
   '>1.0.0 <1.0.2',
   '>=1.0.0 <1.0.2'
-]
-
-[SA-CONTRIB-2023-030]
-field_affected_versions = [
-  '^1 <= 1.0.0',
-  '>=1.0.0 <1.1.0'
 ]
 
 [SA-CONTRIB-2025-087]


### PR DESCRIPTION
This should make it easier to maintain our patches since you can easily predict where in the file a patch for a particular advisory will be - at this point I don't think we need a script to enforce this since we'll hopefully only have a handful of patches at any one time