### PR TITLE
fix: patch `SA-CONTRIB-2022-047`

### DIFF
--- a/advisories/config_terms/DSA-CONTRIB-2022-047.json
+++ b/advisories/config_terms/DSA-CONTRIB-2022-047.json
@@ -20,16 +20,17 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.0.6"
+              "fixed": "1.6.0"
             }
           ],
           "database_specific": {
-            "constraint": "<1.0.6"
+            "constraint": "<1.6.0"
           }
         }
       ],
       "database_specific": {
-        "affected_versions": "<1.0.6"
+        "affected_versions": "<1.6.0",
+        "patched": true
       }
     }
   ],

--- a/patches.toml
+++ b/patches.toml
@@ -10,6 +10,13 @@ field_affected_versions = [
   '>7.0 <=7.86',
   '>=7.0 <=7.86'
 ]
+
+[SA-CONTRIB-2022-047]
+field_affected_versions = [
+  '<1.0.6',
+  '<1.6.0'
+]
+
 [SA-CONTRIB-2024-042]
 field_affected_versions = [
   '<1.8.0 || >=2.0.0 <2.0.0-beta3',


### PR DESCRIPTION
Currently it seems the affected versions incorrectly states 1.0.6 was the patched version, as the "solution" section says to install `8.x-1.6` which would [map to `1.6.0`](https://www.drupal.org/docs/develop/using-composer/manage-dependencies#s-about-semantic-versioning) and that matches the [changelog for that version](https://www.drupal.org/project/config_terms/releases/8.x-1.6) which says it patched this security issue