### PR TITLE
fix: update patch for `SA-CONTRIB-2024-004`

### DIFF
--- a/advisories/social/DSA-CONTRIB-2024-004.json
+++ b/advisories/social/DSA-CONTRIB-2024-004.json
@@ -22,16 +22,16 @@
               "introduced": "0"
             },
             {
-              "fixed": "12.5.0"
+              "fixed": "12.0.5"
             }
           ],
           "database_specific": {
-            "constraint": "<12.5"
+            "constraint": "<12.0.5"
           }
         }
       ],
       "database_specific": {
-        "affected_versions": "<12.5",
+        "affected_versions": "<12.0.5",
         "patched": true
       }
     }

--- a/patches.toml
+++ b/patches.toml
@@ -31,7 +31,7 @@ field_affected_versions = [
 [SA-CONTRIB-2024-004]
 field_affected_versions = [
   '<12.05',
-  '<12.5'
+  '<12.0.5'
 ]
 
 [SA-CONTRIB-2024-038]


### PR DESCRIPTION
It turns out the mistake here is a missing `.` in the version range rather than an extra leading zero, as evident by the advisory saying to install 12.0.5 as the solution, and the [changelog](https://www.drupal.org/project/social/releases/12.0.5) for that version saying it patches this