### PR TITLE
feat: mention advisories that have warnings as part of validation

### DIFF
--- a/scripts/validate_advisories.py
+++ b/scripts/validate_advisories.py
@@ -2,9 +2,12 @@
 
 import json
 import os
+import typing
 from textwrap import indent
 
 import jsonschema
+
+from typings import osv
 
 report_valid = False
 
@@ -16,19 +19,46 @@ with open('schema.json') as f:
 total = 0
 passed = 0
 
+
+def load_advisory_data(path_to_advisory: str) -> osv.Vulnerability:
+  with open(path_to_advisory) as fi:
+    return typing.cast(osv.Vulnerability, json.load(fi))
+
+
+def has_database_specific_warnings(vuln: osv.Vulnerability) -> bool:
+  if len(vuln.get('database_specific', {}).get('warnings', [])) > 0:
+    return True
+
+  for affected in vuln['affected']:
+    if len(affected.get('database_specific', {}).get('warnings', [])) > 0:
+      return True
+    for ran in affected['ranges']:
+      if len(ran.get('database_specific', {}).get('warnings', [])) > 0:
+        return True
+  return False
+
+
 for dirpath, _, filenames in os.walk('advisories'):
   for filename in filenames:
-    advisory = os.path.join(dirpath, filename)
+    advisory_filepath = os.path.join(dirpath, filename)
     total += 1
 
     try:
-      with open(advisory) as f:
-        validator.validate(json.load(f))
-      if report_valid:
-        print(f'✅ {advisory} is valid')
+      data = load_advisory_data(advisory_filepath)
+
+      validator.validate(data)
+
+      if has_database_specific_warnings(data):
+        if 'CI' in os.environ:
+          print(
+            f'::warning file={advisory_filepath},line=1::has warnings that should be reviewed and patched if possible'
+          )
+        print(f'⚠️ {advisory_filepath} is valid with warnings')
+      elif report_valid:
+        print(f'✅ {advisory_filepath} is valid')
       passed += 1
     except (json.JSONDecodeError, jsonschema.ValidationError) as err:
-      print(f'❌ {advisory} is invalid')
+      print(f'❌ {advisory_filepath} is invalid')
       print(indent(str(err), prefix='    '))
 
 print(f'ℹ️ validated {total} advisories, with {total - passed} invalid')


### PR DESCRIPTION
This should help make warnings in advisories stand-out especially for pull requests that add new advisories where the whole diff is just green - this makes use of [GitHub Actions annotations (triggered by a log format)](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message) to add a visual element to each advisory:

![image](https://github.com/user-attachments/assets/c9259b75-8699-4b1a-be74-cfc10cff8954)

For now it appears at the top of the file since it would be more work to try and determine the line number of the `warnings` properties, and I'm not sure it's worth doing that when ideally in the long-run we want to be working with the upstream to avoid warnings in the first place, but it's something we could explore later if desired or someone was bored 😄 