### PR TITLE
refactor: clean up sa downloader script

### DIFF
--- a/scripts/download_sa_advisories.py
+++ b/scripts/download_sa_advisories.py
@@ -72,8 +72,7 @@ def download_sa_advisories_from_rest_api(last_modified_timestamp: int) -> None:
     print(' \\- finished processing page')
     if 'next' in data and data['next'] != '':
       url = data['next'].replace('api-d7/node?', 'api-d7/node.json?')
-    else:
-      print('finished processing new and updated advisories')
+  print('finished processing new and updated advisories')
 
 
 most_recent_changed_time = get_most_recent_changed_timestamp()

--- a/scripts/download_sa_advisories.py
+++ b/scripts/download_sa_advisories.py
@@ -49,20 +49,18 @@ def download_sa_advisories_from_rest_api(last_modified_timestamp: int) -> None:
 
   print(f'fetching sa advisories modified after {last_modified_timestamp}')
   url = 'https://www.drupal.org/api-d7/node.json?type=sa&sort=changed&direction=DESC&field_is_psa=0'
-  fetch_again = True
-  while fetch_again:
+  while url != '':
     print(f'fetching {url}')
     response = requests.get(url, headers={'user-agent': user_agent})
     if response.status_code != 200:
       print(f'X API responded {response.status_code}')
-      fetch_again = False
-      continue
+      break
     data: drupal.ApiResponse[drupal.Advisory] = response.json()
     for item in data['list']:
       changed = int(item['changed'])
       if changed <= last_modified_timestamp:
         # We have reached the last modified entry.
-        fetch_again = False
+        url = ''
         break
       advisory_id = determine_sa_id(item)
       print(
@@ -76,7 +74,6 @@ def download_sa_advisories_from_rest_api(last_modified_timestamp: int) -> None:
       url = data['next'].replace('api-d7/node?', 'api-d7/node.json?')
     else:
       print('finished processing new and updated advisories')
-      fetch_again = False
 
 
 most_recent_changed_time = get_most_recent_changed_timestamp()

--- a/scripts/download_sa_advisories.py
+++ b/scripts/download_sa_advisories.py
@@ -56,6 +56,7 @@ def download_sa_advisories_from_rest_api(last_modified_timestamp: int) -> None:
       print(f'X API responded {response.status_code}')
       break
     data: drupal.ApiResponse[drupal.Advisory] = response.json()
+    url = data.get('next', '').replace('api-d7/node?', 'api-d7/node.json?')
     for item in data['list']:
       changed = int(item['changed'])
       if changed <= last_modified_timestamp:
@@ -70,8 +71,6 @@ def download_sa_advisories_from_rest_api(last_modified_timestamp: int) -> None:
         json.dump(item, f)
         f.write('\n')
     print(' \\- finished processing page')
-    if 'next' in data and data['next'] != '':
-      url = data['next'].replace('api-d7/node?', 'api-d7/node.json?')
   print('finished processing new and updated advisories')
 
 


### PR DESCRIPTION
This reduces some of the indenting by using early exits/breaks rather than `else`s, and reuses the `url` as the loop condition to avoid needing a dedicated variable for when we want to exit the outer loop early